### PR TITLE
Added support for saleae Logic 2.3.31

### DIFF
--- a/PCM2Wav/PCM/logic/saleae.py
+++ b/PCM2Wav/PCM/logic/saleae.py
@@ -10,9 +10,9 @@ class I2S(PCM):
     '''
         I2S data parser for the saleae logic analyzer
     '''
-    TIME_LOC = 0
-    VALUE_LOC = -1
-    CHANNEL_LOC = -2
+    TIME_LOC = 2
+    VALUE_LOC = 5
+    CHANNEL_LOC = 4
     FIRST_D = 1
 
     def __init__(self, csv_file, delimiter=','):


### PR DESCRIPTION
In Logic 2 the sequence of rows has changed and is as follows:

1. name
2. type
3. start_time
4. duration
5. channel
6. data

This commit attempts to fix the new ordering and make the program compatible with Logic 2.X.